### PR TITLE
Fixed stdout, stderr. Running daemon with "-u"

### DIFF
--- a/python/daemon-stdout/spawner.py
+++ b/python/daemon-stdout/spawner.py
@@ -11,7 +11,7 @@ print("STDERR FD: " + str(_stderr_fd))
 print("STDERR: " + _stderr)
 
 print("Starting")
-daemon = subprocess.Popen(["python", "daemon.py"], stdout=_stdout_fd, stderr=_stderr_fd)
+daemon = subprocess.Popen(["python", "-u", "daemon.py"], stdout=_stdout_fd, stderr=_stderr_fd)
 
 time.sleep(20)
 


### PR DESCRIPTION
-u     Force stdin, stdout and stderr to be totally unbuffered.  On systems where it matters, also put stdin, stdout and  stderr  in  binary  mode.   Note  that there is internal buffering in xreadlines(), readlines() and file-object iterators ("for line in sys.stdin") which  is not influenced by this option.  To work around this, you will want to use "sys.stdin.readline()" inside a "while 1:" loop.
